### PR TITLE
fix(contracts): enforce vendor-only auth and double-redeem protection for voucher tokens

### DIFF
--- a/Contracts/escrow/src/escrow.rs
+++ b/Contracts/escrow/src/escrow.rs
@@ -73,6 +73,7 @@ pub fn fund(
 /// Admin approves a farmer for an escrow, transitioning to VoucherMinted state.
 pub fn approve_farmer(
     env: &Env,
+    admin: &Address,
     escrow_id: BytesN<32>,
     farmer: Address,
 ) -> Result<(), Error> {
@@ -89,8 +90,8 @@ pub fn approve_farmer(
     record.farmer = Some(farmer.clone());
     record.state = EscrowState::VoucherMinted;
 
-    // Mint voucher tokens to farmer
-    voucher::mint_voucher(env, &farmer, record.amount);
+    // Mint voucher tokens to farmer — admin auth enforced inside mint_voucher
+    voucher::mint_voucher(env, admin, &farmer, record.amount);
 
     env.storage().persistent().set(&DataKey::Escrow(escrow_id.clone()), &record);
     events::farmer_approved(env, &escrow_id, &farmer);
@@ -107,6 +108,9 @@ pub fn redeem_voucher(
     vendor: Address,
 ) -> Result<(), Error> {
     vendor.require_auth();
+
+    // Enforce vendor role via RBAC before any state change
+    crate::rbac::RBAC::require_vendor(env, &vendor)?;
 
     let mut record: EscrowRecord = env
         .storage()

--- a/Contracts/escrow/src/lib.rs
+++ b/Contracts/escrow/src/lib.rs
@@ -108,12 +108,12 @@ impl EscrowContract {
         farmer: Address,
     ) -> Result<(), Error> {
         rbac::RBAC::require_not_paused(&env)?;
-        require_admin_auth(&env)?;
+        let admin = require_admin_auth(&env)?;
         env.storage()
             .persistent()
             .set(&DataKey::UserRole(farmer.clone()), &Role::Farmer);
         events::role_assigned(&env, &farmer, &Role::Farmer);
-        escrow::approve_farmer(&env, escrow_id, farmer)
+        escrow::approve_farmer(&env, &admin, escrow_id, farmer)
     }
 
     /// Vendor burns voucher and receives USDC.

--- a/Contracts/escrow/src/storage.rs
+++ b/Contracts/escrow/src/storage.rs
@@ -107,6 +107,8 @@ pub enum DataKey {
     ContractAbi(BytesN<32>),
     /// ABI version counter per contract
     AbiVersion(BytesN<32>),
+    /// Tracks whether a voucher for an escrow has been consumed (double-redeem guard)
+    VoucherConsumed(BytesN<32>),
 }
 
 pub const APPROVAL_TIMEOUT_LEDGERS: u32 = 100_800;   // ~7 days at 6s/ledger

--- a/Contracts/escrow/src/voucher.rs
+++ b/Contracts/escrow/src/voucher.rs
@@ -15,15 +15,17 @@ use crate::storage::{ContractAbi, DataKey};
 // ---------------------------------------------------------------------------
 
 /// Mint `amount` voucher tokens to `farmer`.
-/// Called internally after admin approves a farmer.
-pub fn mint_voucher(env: &Env, farmer: &Address, amount: i128) {
+/// Requires admin authorization — only the contract admin may mint.
+pub fn mint_voucher(env: &Env, admin: &Address, farmer: &Address, amount: i128) {
+    admin.require_auth();
     let key = DataKey::VoucherBalance(farmer.clone());
     let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
     env.storage().persistent().set(&key, &(current + amount));
 }
 
 /// Burn `amount` voucher tokens from `farmer`.
-/// Only callable when the destination is an approved vendor.
+/// Requires vendor authorization and vendor role (RBAC).
+/// Guards against double-redeem via a per-escrow consumed flag.
 pub fn burn_voucher(
     env: &Env,
     escrow_id: &BytesN<32>,
@@ -31,25 +33,36 @@ pub fn burn_voucher(
     vendor: &Address,
     amount: i128,
 ) -> Result<i128, Error> {
-    // Vendor must be approved for transfer restriction
+    // Vendor must authenticate
+    vendor.require_auth();
+
+    // Vendor must hold the Vendor role (RBAC)
+    crate::rbac::RBAC::require_vendor(env, vendor)?;
+
+    // Vendor must be in the approved-address whitelist
     let vendor_approved: bool = env
         .storage()
         .persistent()
         .get(&DataKey::VendorAddress(vendor.clone()))
         .unwrap_or(false);
-
     if !vendor_approved {
         return Err(Error::TransferRestricted);
     }
 
+    // Double-redeem guard: each escrow voucher can only be burned once
+    let consumed_key = DataKey::VoucherConsumed(escrow_id.clone());
+    if env.storage().persistent().get::<_, bool>(&consumed_key).unwrap_or(false) {
+        return Err(Error::VoucherAlreadyMinted); // reused as "already consumed"
+    }
+
     let key = DataKey::VoucherBalance(farmer.clone());
     let balance: i128 = env.storage().persistent().get(&key).unwrap_or(0);
-
     if balance < amount {
         return Err(Error::InsufficientBalance);
     }
 
     env.storage().persistent().set(&key, &(balance - amount));
+    env.storage().persistent().set(&consumed_key, &true);
     events::voucher_burned(env, escrow_id, vendor, amount);
 
     Ok(amount)

--- a/Contracts/escrow/tests/integration.rs
+++ b/Contracts/escrow/tests/integration.rs
@@ -289,8 +289,101 @@ fn test_abi_validate_matching_schema() {
 }
 
 // ---------------------------------------------------------------------------
-// Repayment streaming tests
+// Security tests (Issue #32 — Voucher Token Security)
 // ---------------------------------------------------------------------------
+
+/// Non-admin cannot trigger voucher minting (approve_farmer is admin-gated).
+#[test]
+#[should_panic]
+fn test_unauthorized_mint_rejected() {
+    let env = create_env();
+    // Do NOT mock_all_auths — we want real auth enforcement
+    let (usdc_id, client, _admin, _oracle) = setup(&env);
+
+    let sender = Address::generate(&env);
+    let farmer = Address::generate(&env);
+    let vendor_id: BytesN<32> = BytesN::from_array(&env, &[20u8; 32]);
+    let amount: i128 = 100_000_000;
+
+    let usdc_client = soroban_sdk::token::StellarAssetClient::new(&env, &usdc_id);
+    // Mint USDC to sender and mock only sender's auth for fund()
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &sender,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "fund",
+            args: soroban_sdk::vec![
+                &env,
+                usdc_id.clone().into(),
+                sender.clone().into(),
+                vendor_id.clone().into(),
+                Symbol::new(&env, "2025X").into(),
+                amount.into(),
+            ],
+            sub_invokes: &[],
+        },
+    }]);
+    usdc_client.mint(&sender, &amount);
+    let escrow_id = client.fund(&usdc_id, &sender, &vendor_id, &Symbol::new(&env, "2025X"), &amount);
+
+    // Attempt approve_farmer without admin auth — should panic
+    client.approve_farmer(&escrow_id, &farmer);
+}
+
+/// A non-vendor address cannot redeem a voucher.
+#[test]
+#[should_panic]
+fn test_unauthorized_redeem_rejected() {
+    let env = create_env();
+    env.mock_all_auths();
+
+    let (usdc_id, client, _admin, _oracle) = setup(&env);
+
+    let sender = Address::generate(&env);
+    let farmer = Address::generate(&env);
+    let non_vendor = Address::generate(&env); // never registered as vendor
+    let vendor_id: BytesN<32> = BytesN::from_array(&env, &[21u8; 32]);
+    let amount: i128 = 100_000_000;
+
+    let usdc_client = soroban_sdk::token::StellarAssetClient::new(&env, &usdc_id);
+    usdc_client.mint(&sender, &amount);
+
+    let escrow_id = client.fund(&usdc_id, &sender, &vendor_id, &Symbol::new(&env, "2025Y"), &amount);
+    client.approve_farmer(&escrow_id, &farmer);
+
+    // non_vendor has no Vendor role and is not in the approved-address list
+    client.redeem_voucher(&usdc_id, &escrow_id, &non_vendor);
+}
+
+/// A voucher cannot be redeemed twice (double-redeem protection).
+#[test]
+#[should_panic]
+fn test_double_redeem_rejected() {
+    let env = create_env();
+    env.mock_all_auths();
+
+    let (usdc_id, client, _admin, _oracle) = setup(&env);
+
+    let sender = Address::generate(&env);
+    let farmer = Address::generate(&env);
+    let vendor = Address::generate(&env);
+    let vendor_id: BytesN<32> = BytesN::from_array(&env, &[22u8; 32]);
+    let amount: i128 = 100_000_000;
+
+    let usdc_client = soroban_sdk::token::StellarAssetClient::new(&env, &usdc_id);
+    usdc_client.mint(&sender, &amount);
+
+    client.approve_vendor_address(&vendor);
+
+    let escrow_id = client.fund(&usdc_id, &sender, &vendor_id, &Symbol::new(&env, "2025Z"), &amount);
+    client.approve_farmer(&escrow_id, &farmer);
+
+    // First redemption — succeeds
+    client.redeem_voucher(&usdc_id, &escrow_id, &vendor);
+
+    // Second redemption — must panic (VoucherConsumed flag set)
+    client.redeem_voucher(&usdc_id, &escrow_id, &vendor);
+}
 
 #[test]
 fn test_trigger_repay_sets_deadline() {


### PR DESCRIPTION
## Summary

Resolves #32 — Voucher Token Security

The voucher token system lacked critical access control checks, allowing any caller to mint RVCH tokens or redeem vouchers without proper authorization. This PR closes all three attack vectors identified in the issue.

---

## Security Fixes

### 1. Unauthorized Mint Prevention
**File:** `Contracts/escrow/src/voucher.rs`

`mint_voucher` previously had no caller authentication. Any account could have triggered minting by calling `approve_farmer` without admin credentials.

**Fix:** `mint_voucher` now accepts an `admin: &Address` parameter and calls `admin.require_auth()` before writing any state. The admin address is threaded from `lib.rs → escrow::approve_farmer → voucher::mint_voucher`.

### 2. Unauthorized Redeem Prevention
**Files:** `Contracts/escrow/src/voucher.rs`, `Contracts/escrow/src/escrow.rs`

`burn_voucher` only checked the vendor whitelist (`VendorAddress`) but did not verify the caller's identity or RBAC role. `redeem_voucher` in `escrow.rs` called `vendor.require_auth()` but skipped the RBAC role check.

**Fix:**
- `burn_voucher` now calls `vendor.require_auth()` + `RBAC::require_vendor()` + whitelist check (defense-in-depth)
- `redeem_voucher` in `escrow.rs` adds `RBAC::require_vendor()` before any state mutation

### 3. Double-Redeem Protection
**Files:** `Contracts/escrow/src/storage.rs`, `Contracts/escrow/src/voucher.rs`

No guard existed to prevent a vendor from calling `redeem_voucher` twice on the same escrow.

**Fix:**
- Added `VoucherConsumed(BytesN<32>)` to `DataKey` enum
- `burn_voucher` checks this flag before burning and sets it atomically after a successful burn
- Any subsequent burn attempt on the same escrow returns `Error::VoucherAlreadyMinted`

---

## Tests Added

`Contracts/escrow/tests/integration.rs` — three new `#[should_panic]` tests:

| Test | Scenario |
|---|---|
| `test_unauthorized_mint_rejected` | Non-admin calls `approve_farmer` without admin auth — panics |
| `test_unauthorized_redeem_rejected` | Address with no Vendor role calls `redeem_voucher` — panics |
| `test_double_redeem_rejected` | Vendor redeems the same escrow twice — second call panics |

---

## Files Changed

| File | Change |
|---|---|
| `src/voucher.rs` | `mint_voucher` takes `admin` param + `require_auth()`; `burn_voucher` adds vendor auth + RBAC + double-redeem guard |
| `src/escrow.rs` | `approve_farmer` passes `admin` to `mint_voucher`; `redeem_voucher` adds `RBAC::require_vendor` |
| `src/lib.rs` | `approve_farmer` passes resolved admin to `escrow::approve_farmer` |
| `src/storage.rs` | Added `VoucherConsumed(BytesN<32>)` variant to `DataKey` |
| `tests/integration.rs` | 3 new security tests |

---

## Testing

```bash
cd Contracts
cargo test
```

All existing tests continue to pass (they use `mock_all_auths` which satisfies the new auth requirements). The three new tests assert the correct panic behavior for each attack vector.