### PR TITLE
feat(backend-api): implement escrow state synchronization

### DIFF
--- a/Backend/backend-api/src/__tests__/escrow.sync.test.ts
+++ b/Backend/backend-api/src/__tests__/escrow.sync.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Tests for EscrowSyncService and /api/escrows routes.
+ *
+ * The database is mocked via jest.mock so no real Postgres connection is needed.
+ */
+
+import { EscrowSyncService } from '../services/escrow.sync.service';
+import { EscrowState, isValidTransition } from '../models/Escrow';
+import { Logger } from '../utils/logger';
+
+const logger = new Logger('test');
+
+// ─── Model: isValidTransition ─────────────────────────────────────────────────
+
+describe('isValidTransition', () => {
+  it('allows Created → Funded', () => {
+    expect(isValidTransition(EscrowState.Created, EscrowState.Funded)).toBe(true);
+  });
+
+  it('allows Created → Cancelled', () => {
+    expect(isValidTransition(EscrowState.Created, EscrowState.Cancelled)).toBe(true);
+  });
+
+  it('allows Funded → VoucherMinted', () => {
+    expect(isValidTransition(EscrowState.Funded, EscrowState.VoucherMinted)).toBe(true);
+  });
+
+  it('allows VoucherMinted → Redeemed', () => {
+    expect(isValidTransition(EscrowState.VoucherMinted, EscrowState.Redeemed)).toBe(true);
+  });
+
+  it('allows Redeemed → Repaying', () => {
+    expect(isValidTransition(EscrowState.Redeemed, EscrowState.Repaying)).toBe(true);
+  });
+
+  it('allows Repaying → Repaid', () => {
+    expect(isValidTransition(EscrowState.Repaying, EscrowState.Repaid)).toBe(true);
+  });
+
+  it('allows Repaying → Defaulted', () => {
+    expect(isValidTransition(EscrowState.Repaying, EscrowState.Defaulted)).toBe(true);
+  });
+
+  it('rejects backward transition Redeemed → Funded', () => {
+    expect(isValidTransition(EscrowState.Redeemed, EscrowState.Funded)).toBe(false);
+  });
+
+  it('rejects transition from terminal state Repaid', () => {
+    expect(isValidTransition(EscrowState.Repaid, EscrowState.Repaying)).toBe(false);
+  });
+
+  it('rejects transition from terminal state Defaulted', () => {
+    expect(isValidTransition(EscrowState.Defaulted, EscrowState.Repaid)).toBe(false);
+  });
+
+  it('rejects transition from terminal state Cancelled', () => {
+    expect(isValidTransition(EscrowState.Cancelled, EscrowState.Funded)).toBe(false);
+  });
+});
+
+// ─── EscrowSyncService ────────────────────────────────────────────────────────
+
+describe('EscrowSyncService', () => {
+  const baseEscrow = {
+    id: 'uuid-1',
+    contract_escrow_id: 'escrow-abc',
+    contract_id: 'contract-xyz',
+    state: EscrowState.Created,
+    sender_address: 'GABC',
+    farmer_address: null,
+    vendor_id: null,
+    amount: 200_000_000,
+    currency: 'USDC',
+    crop_season: '2026-A',
+    last_ledger_sequence: 100,
+    last_tx_hash: 'tx-hash-1',
+    synced_at: '2026-01-01T00:00:00.000Z',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+
+  describe('createEscrow', () => {
+    it('inserts a new escrow and returns it', async () => {
+      const inserted = { ...baseEscrow };
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(undefined), // not found → create
+        insert: jest.fn().mockReturnThis(),
+        returning: jest.fn().mockResolvedValue([inserted]),
+      };
+      const db = jest.fn().mockImplementation(() => qb) as any;
+      db.fn = { now: jest.fn() };
+
+      const svc = new EscrowSyncService(db, logger);
+      const result = await svc.createEscrow({
+        contract_escrow_id: 'escrow-abc',
+        contract_id: 'contract-xyz',
+        state: EscrowState.Created,
+        sender_address: 'GABC',
+        amount: 200_000_000,
+        currency: 'USDC',
+        last_ledger_sequence: 100,
+        last_tx_hash: 'tx-hash-1',
+      });
+
+      expect(result.contract_escrow_id).toBe('escrow-abc');
+      expect(qb.insert).toHaveBeenCalled();
+    });
+
+    it('returns existing escrow without inserting on duplicate', async () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(baseEscrow),
+        insert: jest.fn().mockReturnThis(),
+        returning: jest.fn().mockResolvedValue([]),
+      };
+      const db = jest.fn().mockImplementation(() => qb) as any;
+      db.fn = { now: jest.fn() };
+
+      const svc = new EscrowSyncService(db, logger);
+      const result = await svc.createEscrow({
+        contract_escrow_id: 'escrow-abc',
+        contract_id: 'contract-xyz',
+        state: EscrowState.Created,
+        sender_address: 'GABC',
+        amount: 200_000_000,
+        currency: 'USDC',
+        last_ledger_sequence: 100,
+      });
+
+      expect(result).toEqual(baseEscrow);
+      expect(qb.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('applyStateTransition', () => {
+    it('applies a valid state transition', async () => {
+      const updated = { ...baseEscrow, state: EscrowState.Funded, last_ledger_sequence: 200 };
+      let callCount = 0;
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockImplementation(() => {
+          // first call: find escrow; subsequent: history insert
+          return callCount++ === 0 ? Promise.resolve(baseEscrow) : Promise.resolve(undefined);
+        }),
+        update: jest.fn().mockReturnThis(),
+        returning: jest.fn().mockResolvedValue([updated]),
+        insert: jest.fn().mockReturnThis(),
+      };
+      const db = jest.fn().mockImplementation(() => qb) as any;
+      db.fn = { now: jest.fn() };
+
+      const svc = new EscrowSyncService(db, logger);
+      const result = await svc.applyStateTransition({
+        contract_escrow_id: 'escrow-abc',
+        new_state: EscrowState.Funded,
+        tx_hash: 'tx-hash-2',
+        ledger_sequence: 200,
+        event_type: 'approve_farmer',
+      });
+
+      expect(result?.state).toBe(EscrowState.Funded);
+      expect(qb.update).toHaveBeenCalled();
+    });
+
+    it('skips duplicate event (same tx_hash + same state)', async () => {
+      const escrowSameState = { ...baseEscrow, last_tx_hash: 'tx-dup', state: EscrowState.Funded };
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(escrowSameState),
+        update: jest.fn().mockReturnThis(),
+        returning: jest.fn().mockResolvedValue([]),
+      };
+      const db = jest.fn().mockImplementation(() => qb) as any;
+      db.fn = { now: jest.fn() };
+
+      const svc = new EscrowSyncService(db, logger);
+      const result = await svc.applyStateTransition({
+        contract_escrow_id: 'escrow-abc',
+        new_state: EscrowState.Funded,
+        tx_hash: 'tx-dup',
+        ledger_sequence: 200,
+        event_type: 'approve_farmer',
+      });
+
+      expect(result).toEqual(escrowSameState);
+      expect(qb.update).not.toHaveBeenCalled();
+    });
+
+    it('skips stale event (ledger_sequence ≤ current)', async () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(baseEscrow), // last_ledger_sequence = 100
+        update: jest.fn().mockReturnThis(),
+        returning: jest.fn().mockResolvedValue([]),
+      };
+      const db = jest.fn().mockImplementation(() => qb) as any;
+      db.fn = { now: jest.fn() };
+
+      const svc = new EscrowSyncService(db, logger);
+      const result = await svc.applyStateTransition({
+        contract_escrow_id: 'escrow-abc',
+        new_state: EscrowState.Funded,
+        tx_hash: 'tx-old',
+        ledger_sequence: 50, // older than 100
+        event_type: 'approve_farmer',
+      });
+
+      expect(result).toEqual(baseEscrow);
+      expect(qb.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid state transition', async () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(baseEscrow), // state = Created
+        update: jest.fn().mockReturnThis(),
+        returning: jest.fn().mockResolvedValue([]),
+      };
+      const db = jest.fn().mockImplementation(() => qb) as any;
+      db.fn = { now: jest.fn() };
+
+      const svc = new EscrowSyncService(db, logger);
+      const result = await svc.applyStateTransition({
+        contract_escrow_id: 'escrow-abc',
+        new_state: EscrowState.Repaid, // invalid from Created
+        tx_hash: 'tx-bad',
+        ledger_sequence: 200,
+        event_type: 'repay',
+      });
+
+      expect(result).toEqual(baseEscrow);
+      expect(qb.update).not.toHaveBeenCalled();
+    });
+
+    it('returns null when escrow not found', async () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(undefined),
+      };
+      const db = jest.fn().mockImplementation(() => qb) as any;
+      db.fn = { now: jest.fn() };
+
+      const svc = new EscrowSyncService(db, logger);
+      const result = await svc.applyStateTransition({
+        contract_escrow_id: 'nonexistent',
+        new_state: EscrowState.Funded,
+        tx_hash: 'tx-x',
+        ledger_sequence: 200,
+        event_type: 'approve_farmer',
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('processContractEvent', () => {
+    it('calls createEscrow for fund event', async () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(undefined),
+        insert: jest.fn().mockReturnThis(),
+        returning: jest.fn().mockResolvedValue([baseEscrow]),
+      };
+      const db = jest.fn().mockImplementation(() => qb) as any;
+      db.fn = { now: jest.fn() };
+
+      const svc = new EscrowSyncService(db, logger);
+      const createSpy = jest.spyOn(svc, 'createEscrow').mockResolvedValue(baseEscrow);
+
+      await svc.processContractEvent({
+        contract_escrow_id: 'escrow-abc',
+        contract_id: 'contract-xyz',
+        event_type: 'fund',
+        tx_hash: 'tx-1',
+        ledger_sequence: 100,
+        sender_address: 'GABC',
+        amount: 200_000_000,
+        currency: 'USDC',
+      });
+
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ contract_escrow_id: 'escrow-abc', state: EscrowState.Created }),
+      );
+    });
+
+    it('calls applyStateTransition for non-fund events', async () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(baseEscrow),
+        update: jest.fn().mockReturnThis(),
+        returning: jest.fn().mockResolvedValue([{ ...baseEscrow, state: EscrowState.Funded }]),
+        insert: jest.fn().mockReturnThis(),
+      };
+      const db = jest.fn().mockImplementation(() => qb) as any;
+      db.fn = { now: jest.fn() };
+
+      const svc = new EscrowSyncService(db, logger);
+      const transitionSpy = jest
+        .spyOn(svc, 'applyStateTransition')
+        .mockResolvedValue({ ...baseEscrow, state: EscrowState.Funded });
+
+      await svc.processContractEvent({
+        contract_escrow_id: 'escrow-abc',
+        contract_id: 'contract-xyz',
+        event_type: 'approve_farmer',
+        tx_hash: 'tx-2',
+        ledger_sequence: 200,
+      });
+
+      expect(transitionSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ new_state: EscrowState.Funded }),
+      );
+    });
+
+    it('ignores unknown event types', async () => {
+      const db = jest.fn() as any;
+      db.fn = { now: jest.fn() };
+      const svc = new EscrowSyncService(db, logger);
+      const createSpy = jest.spyOn(svc, 'createEscrow');
+      const transitionSpy = jest.spyOn(svc, 'applyStateTransition');
+
+      await svc.processContractEvent({
+        contract_escrow_id: 'escrow-abc',
+        contract_id: 'contract-xyz',
+        event_type: 'unknown_event',
+        tx_hash: 'tx-x',
+        ledger_sequence: 100,
+      });
+
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(transitionSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getHistory', () => {
+    it('returns history entries ordered by occurred_at', async () => {
+      const historyRows = [
+        { id: 'h1', escrow_id: 'uuid-1', from_state: null, to_state: EscrowState.Created },
+        { id: 'h2', escrow_id: 'uuid-1', from_state: EscrowState.Created, to_state: EscrowState.Funded },
+      ];
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockResolvedValue(historyRows),
+      };
+      const db = jest.fn().mockImplementation(() => qb) as any;
+      db.fn = { now: jest.fn() };
+
+      const svc = new EscrowSyncService(db, logger);
+      const result = await svc.getHistory('uuid-1');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].to_state).toBe(EscrowState.Created);
+      expect(result[1].to_state).toBe(EscrowState.Funded);
+    });
+  });
+});

--- a/Backend/backend-api/src/db/index.ts
+++ b/Backend/backend-api/src/db/index.ts
@@ -1,0 +1,29 @@
+import Knex, { Knex as KnexType } from 'knex';
+
+/**
+ * Shared Knex instance.
+ * Uses DATABASE_URL when set (production/staging), otherwise falls back to
+ * individual DB_* env vars for local development.
+ *
+ * Lazily initialised so that test suites that mock the DB don't require `pg`.
+ */
+let _db: KnexType | null = null;
+
+export function getDb(): KnexType {
+  if (!_db) {
+    _db = Knex({
+      client: 'pg',
+      connection: process.env.DATABASE_URL ?? {
+        host: process.env.DB_HOST ?? 'localhost',
+        port: Number(process.env.DB_PORT ?? 5432),
+        database: process.env.DB_NAME ?? 'remitroot_db',
+        user: process.env.DB_USER ?? 'admin',
+        password: process.env.DB_PASSWORD ?? '',
+      },
+      pool: { min: 2, max: 10 },
+    });
+  }
+  return _db;
+}
+
+export default getDb;

--- a/Backend/backend-api/src/db/migrations/20260519_create_escrows.ts
+++ b/Backend/backend-api/src/db/migrations/20260519_create_escrows.ts
@@ -1,0 +1,53 @@
+import { Knex } from 'knex';
+
+/**
+ * Migration: create escrows and escrow_history tables.
+ *
+ * escrows        — current state mirror of on-chain escrow contracts
+ * escrow_history — append-only audit log of every state transition
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('escrows', (t) => {
+    t.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    t.string('contract_escrow_id', 128).notNullable().unique();
+    t.string('contract_id', 128).notNullable();
+    t.string('state', 32).notNullable();
+    t.string('sender_address', 64).notNullable();
+    t.string('farmer_address', 64).nullable();
+    t.string('vendor_id', 128).nullable();
+    t.bigInteger('amount').notNullable().defaultTo(0);
+    t.string('currency', 16).notNullable().defaultTo('USDC');
+    t.string('crop_season', 64).nullable();
+    t.bigInteger('last_ledger_sequence').notNullable().defaultTo(0);
+    t.string('last_tx_hash', 128).nullable();
+    t.timestamp('synced_at').notNullable().defaultTo(knex.fn.now());
+    t.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+    t.timestamp('updated_at').notNullable().defaultTo(knex.fn.now());
+
+    t.index('contract_id');
+    t.index('sender_address');
+    t.index('state');
+  });
+
+  await knex.schema.createTable('escrow_history', (t) => {
+    t.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    t.uuid('escrow_id').notNullable().references('id').inTable('escrows').onDelete('CASCADE');
+    t.string('from_state', 32).nullable();
+    t.string('to_state', 32).notNullable();
+    t.string('tx_hash', 128).nullable();
+    t.bigInteger('ledger_sequence').notNullable().defaultTo(0);
+    t.string('event_type', 64).notNullable();
+    t.jsonb('metadata').nullable();
+    t.timestamp('occurred_at').notNullable().defaultTo(knex.fn.now());
+    t.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+
+    t.index('escrow_id');
+    t.index('to_state');
+    t.index('occurred_at');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('escrow_history');
+  await knex.schema.dropTableIfExists('escrows');
+}

--- a/Backend/backend-api/src/index.ts
+++ b/Backend/backend-api/src/index.ts
@@ -7,6 +7,8 @@ import userRoutes from "./routes/users";
 import vendorRoutes from "./routes/vendors";
 import ussdRoutes from "./routes/ussd.routes";
 import momoWebhookRoutes from './routes/momoWebhook.routes';
+import { createEscrowRouter } from './routes/escrows.routes';
+import getDb from './db';
 
 
 // Load environment variables
@@ -26,6 +28,11 @@ app.use(logger);
 app.use("/api/users", userRoutes);
 app.use("/api/vendors", vendorRoutes);
 app.use("/api/ussd", ussdRoutes);
+
+// Escrow routes require a live DB connection — skip in unit-test mode
+if (process.env.NODE_ENV !== 'test') {
+  app.use("/api/escrows", createEscrowRouter(getDb()));
+}
 
 // Health check endpoint
 app.get("/health", (_req, res) => {

--- a/Backend/backend-api/src/models/Escrow.ts
+++ b/Backend/backend-api/src/models/Escrow.ts
@@ -1,0 +1,89 @@
+/**
+ * Escrow model — mirrors the on-chain Soroban escrow contract state.
+ *
+ * State machine (matches contract):
+ *   Created → Funded → VoucherMinted → Redeemed → Repaying → Repaid | Defaulted
+ *                                                                ↑
+ *                                                           (Cancelled)
+ */
+
+export enum EscrowState {
+  Created = 'Created',
+  Funded = 'Funded',
+  VoucherMinted = 'VoucherMinted',
+  Redeemed = 'Redeemed',
+  Repaying = 'Repaying',
+  Repaid = 'Repaid',
+  Defaulted = 'Defaulted',
+  Cancelled = 'Cancelled',
+}
+
+/** Valid forward transitions for conflict resolution */
+export const VALID_TRANSITIONS: Record<EscrowState, EscrowState[]> = {
+  [EscrowState.Created]: [EscrowState.Funded, EscrowState.Cancelled],
+  [EscrowState.Funded]: [EscrowState.VoucherMinted, EscrowState.Cancelled],
+  [EscrowState.VoucherMinted]: [EscrowState.Redeemed],
+  [EscrowState.Redeemed]: [EscrowState.Repaying],
+  [EscrowState.Repaying]: [EscrowState.Repaid, EscrowState.Defaulted],
+  [EscrowState.Repaid]: [],
+  [EscrowState.Defaulted]: [],
+  [EscrowState.Cancelled]: [],
+};
+
+export interface Escrow {
+  id: string;                      // internal UUID
+  contract_escrow_id: string;      // on-chain escrow ID (hex)
+  contract_id: string;             // Soroban contract address
+  state: EscrowState;
+  sender_address: string;          // Stellar public key
+  farmer_address: string | null;
+  vendor_id: string | null;
+  amount: number;                  // in stroops (1 XLM = 10^7 stroops)
+  currency: string;                // e.g. "USDC"
+  crop_season: string | null;
+  last_ledger_sequence: number;
+  last_tx_hash: string | null;
+  synced_at: string;               // ISO timestamp of last sync
+  created_at: string;
+  updated_at: string;
+}
+
+export interface EscrowHistoryEntry {
+  id: string;
+  escrow_id: string;
+  from_state: EscrowState | null;
+  to_state: EscrowState;
+  tx_hash: string | null;
+  ledger_sequence: number;
+  event_type: string;
+  metadata: Record<string, unknown> | null;
+  occurred_at: string;
+  created_at: string;
+}
+
+export interface CreateEscrowDto {
+  contract_escrow_id: string;
+  contract_id: string;
+  state: EscrowState;
+  sender_address: string;
+  farmer_address?: string;
+  vendor_id?: string;
+  amount: number;
+  currency: string;
+  crop_season?: string;
+  last_ledger_sequence: number;
+  last_tx_hash?: string;
+}
+
+export interface UpdateEscrowStateDto {
+  contract_escrow_id: string;
+  new_state: EscrowState;
+  tx_hash: string;
+  ledger_sequence: number;
+  event_type: string;
+  metadata?: Record<string, unknown>;
+}
+
+export function isValidTransition(from: EscrowState, to: EscrowState): boolean {
+  return VALID_TRANSITIONS[from]?.includes(to) ?? false;
+}

--- a/Backend/backend-api/src/routes/escrows.routes.ts
+++ b/Backend/backend-api/src/routes/escrows.routes.ts
@@ -1,0 +1,122 @@
+/**
+ * Escrow routes
+ *
+ * GET  /api/escrows              — list escrows (filterable)
+ * GET  /api/escrows/:id          — get escrow by internal UUID
+ * GET  /api/escrows/contract/:contractEscrowId — get by on-chain ID
+ * GET  /api/escrows/:id/history  — full state-transition history
+ * POST /api/escrows/sync         — manually ingest a contract event
+ */
+
+import { Router, Request, Response, NextFunction } from 'express';
+import { Knex } from 'knex';
+import { createLogger } from '../utils/logger';
+import { EscrowSyncService } from '../services/escrow.sync.service';
+import { EscrowState } from '../models/Escrow';
+
+export function createEscrowRouter(db: Knex): Router {
+  const router = Router();
+  const logger = createLogger('EscrowRouter');
+  const service = new EscrowSyncService(db, logger);
+
+  /**
+   * GET /api/escrows
+   * Query params: state, sender_address, contract_id, page, limit
+   */
+  router.get('/', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const result = await service.list({
+        state: req.query.state as EscrowState | undefined,
+        sender_address: req.query.sender_address as string | undefined,
+        contract_id: req.query.contract_id as string | undefined,
+        page: req.query.page ? Number(req.query.page) : 1,
+        limit: req.query.limit ? Number(req.query.limit) : 20,
+      });
+      res.json({ success: true, ...result });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  /**
+   * GET /api/escrows/contract/:contractEscrowId
+   * Look up by on-chain escrow ID (must come before /:id to avoid shadowing)
+   */
+  router.get(
+    '/contract/:contractEscrowId',
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      try {
+        const escrow = await service.getByContractEscrowId(req.params.contractEscrowId);
+        if (!escrow) {
+          res.status(404).json({ success: false, message: 'Escrow not found' });
+          return;
+        }
+        res.json({ success: true, data: escrow });
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  /**
+   * GET /api/escrows/:id
+   */
+  router.get('/:id', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const escrow = await service.getById(req.params.id);
+      if (!escrow) {
+        res.status(404).json({ success: false, message: 'Escrow not found' });
+        return;
+      }
+      res.json({ success: true, data: escrow });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  /**
+   * GET /api/escrows/:id/history
+   */
+  router.get('/:id/history', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const escrow = await service.getById(req.params.id);
+      if (!escrow) {
+        res.status(404).json({ success: false, message: 'Escrow not found' });
+        return;
+      }
+      const history = await service.getHistory(req.params.id);
+      res.json({ success: true, data: history });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  /**
+   * POST /api/escrows/sync
+   * Ingest a contract event (called by the Horizon indexer or manually).
+   * Body: { contract_escrow_id, contract_id, event_type, tx_hash,
+   *         ledger_sequence, sender_address?, farmer_address?,
+   *         vendor_id?, amount?, currency?, crop_season?, metadata? }
+   */
+  router.post('/sync', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const { contract_escrow_id, contract_id, event_type, tx_hash, ledger_sequence } = req.body;
+
+      if (!contract_escrow_id || !contract_id || !event_type || !tx_hash || !ledger_sequence) {
+        res.status(400).json({
+          success: false,
+          message:
+            'contract_escrow_id, contract_id, event_type, tx_hash, and ledger_sequence are required',
+        });
+        return;
+      }
+
+      await service.processContractEvent(req.body);
+      res.status(202).json({ success: true, message: 'Event accepted for processing' });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/Backend/backend-api/src/services/escrow.sync.service.ts
+++ b/Backend/backend-api/src/services/escrow.sync.service.ts
@@ -1,0 +1,294 @@
+/**
+ * EscrowSyncService
+ *
+ * Indexes Horizon/Soroban contract events and keeps the `escrows` table in
+ * sync with on-chain state.  Responsibilities:
+ *   - Upsert escrow records from contract events
+ *   - Validate state transitions (conflict resolution)
+ *   - Append every transition to escrow_history
+ *   - Expose query helpers used by the REST routes
+ */
+
+import { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+import { Logger } from '../utils/logger';
+import {
+  Escrow,
+  EscrowHistoryEntry,
+  EscrowState,
+  CreateEscrowDto,
+  UpdateEscrowStateDto,
+  isValidTransition,
+} from '../models/Escrow';
+
+export class EscrowSyncService {
+  constructor(
+    private readonly db: Knex,
+    private readonly logger: Logger,
+  ) {}
+
+  // ─── Upsert (called by the Horizon event processor) ──────────────────────
+
+  /**
+   * Create a new escrow record from a `fund()` contract event.
+   * Idempotent: returns the existing record if already present.
+   */
+  async createEscrow(dto: CreateEscrowDto): Promise<Escrow> {
+    const existing = await this.db('escrows')
+      .where('contract_escrow_id', dto.contract_escrow_id)
+      .first();
+
+    if (existing) {
+      this.logger.warn('Escrow already exists, skipping create', {
+        contract_escrow_id: dto.contract_escrow_id,
+      });
+      return existing as Escrow;
+    }
+
+    const now = new Date().toISOString();
+    const id = uuidv4();
+
+    const [record] = await this.db('escrows')
+      .insert({
+        id,
+        contract_escrow_id: dto.contract_escrow_id,
+        contract_id: dto.contract_id,
+        state: dto.state,
+        sender_address: dto.sender_address,
+        farmer_address: dto.farmer_address ?? null,
+        vendor_id: dto.vendor_id ?? null,
+        amount: dto.amount,
+        currency: dto.currency,
+        crop_season: dto.crop_season ?? null,
+        last_ledger_sequence: dto.last_ledger_sequence,
+        last_tx_hash: dto.last_tx_hash ?? null,
+        synced_at: now,
+        created_at: now,
+        updated_at: now,
+      })
+      .returning('*');
+
+    await this.appendHistory({
+      escrow_id: id,
+      from_state: null,
+      to_state: dto.state,
+      tx_hash: dto.last_tx_hash ?? null,
+      ledger_sequence: dto.last_ledger_sequence,
+      event_type: 'escrow_created',
+      metadata: null,
+    });
+
+    this.logger.info('Escrow created', { id, contract_escrow_id: dto.contract_escrow_id });
+    return record as Escrow;
+  }
+
+  /**
+   * Apply a state transition from a contract event.
+   *
+   * Conflict resolution rules:
+   *   1. Duplicate event (same tx_hash + same state) → silently skip.
+   *   2. Invalid transition (e.g. Redeemed → Funded) → log warning, skip.
+   *   3. Stale event (ledger_sequence ≤ last known) → skip.
+   *   4. Valid forward transition → update + append history.
+   */
+  async applyStateTransition(dto: UpdateEscrowStateDto): Promise<Escrow | null> {
+    const escrow = await this.db('escrows')
+      .where('contract_escrow_id', dto.contract_escrow_id)
+      .first() as Escrow | undefined;
+
+    if (!escrow) {
+      this.logger.warn('Escrow not found for state transition', {
+        contract_escrow_id: dto.contract_escrow_id,
+      });
+      return null;
+    }
+
+    // 1. Duplicate event guard
+    if (escrow.last_tx_hash === dto.tx_hash && escrow.state === dto.new_state) {
+      this.logger.info('Duplicate event skipped', { tx_hash: dto.tx_hash });
+      return escrow;
+    }
+
+    // 2. Stale event guard
+    if (dto.ledger_sequence <= escrow.last_ledger_sequence) {
+      this.logger.warn('Stale event skipped', {
+        contract_escrow_id: dto.contract_escrow_id,
+        incoming_ledger: dto.ledger_sequence,
+        current_ledger: escrow.last_ledger_sequence,
+      });
+      return escrow;
+    }
+
+    // 3. Validate transition
+    if (!isValidTransition(escrow.state, dto.new_state)) {
+      this.logger.warn('Invalid state transition rejected', {
+        contract_escrow_id: dto.contract_escrow_id,
+        from: escrow.state,
+        to: dto.new_state,
+      });
+      return escrow;
+    }
+
+    const now = new Date().toISOString();
+
+    const [updated] = await this.db('escrows')
+      .where('id', escrow.id)
+      .update({
+        state: dto.new_state,
+        last_tx_hash: dto.tx_hash,
+        last_ledger_sequence: dto.ledger_sequence,
+        synced_at: now,
+        updated_at: now,
+      })
+      .returning('*');
+
+    await this.appendHistory({
+      escrow_id: escrow.id,
+      from_state: escrow.state,
+      to_state: dto.new_state,
+      tx_hash: dto.tx_hash,
+      ledger_sequence: dto.ledger_sequence,
+      event_type: dto.event_type,
+      metadata: dto.metadata ?? null,
+    });
+
+    this.logger.info('Escrow state updated', {
+      id: escrow.id,
+      from: escrow.state,
+      to: dto.new_state,
+    });
+
+    return updated as Escrow;
+  }
+
+  // ─── History ──────────────────────────────────────────────────────────────
+
+  private async appendHistory(entry: {
+    escrow_id: string;
+    from_state: EscrowState | null;
+    to_state: EscrowState;
+    tx_hash: string | null;
+    ledger_sequence: number;
+    event_type: string;
+    metadata: Record<string, unknown> | null;
+  }): Promise<void> {
+    const now = new Date().toISOString();
+    await this.db('escrow_history').insert({
+      id: uuidv4(),
+      escrow_id: entry.escrow_id,
+      from_state: entry.from_state,
+      to_state: entry.to_state,
+      tx_hash: entry.tx_hash,
+      ledger_sequence: entry.ledger_sequence,
+      event_type: entry.event_type,
+      metadata: entry.metadata ? JSON.stringify(entry.metadata) : null,
+      occurred_at: now,
+      created_at: now,
+    });
+  }
+
+  async getHistory(escrowId: string): Promise<EscrowHistoryEntry[]> {
+    return this.db('escrow_history')
+      .where('escrow_id', escrowId)
+      .orderBy('occurred_at', 'asc') as Promise<EscrowHistoryEntry[]>;
+  }
+
+  // ─── Queries ──────────────────────────────────────────────────────────────
+
+  async getById(id: string): Promise<Escrow | null> {
+    const row = await this.db('escrows').where('id', id).first();
+    return (row as Escrow) ?? null;
+  }
+
+  async getByContractEscrowId(contractEscrowId: string): Promise<Escrow | null> {
+    const row = await this.db('escrows')
+      .where('contract_escrow_id', contractEscrowId)
+      .first();
+    return (row as Escrow) ?? null;
+  }
+
+  async list(filter: {
+    state?: EscrowState;
+    sender_address?: string;
+    contract_id?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<{ data: Escrow[]; total: number; page: number; limit: number }> {
+    const page = filter.page ?? 1;
+    const limit = Math.min(filter.limit ?? 20, 100);
+    const offset = (page - 1) * limit;
+
+    let query = this.db('escrows');
+    if (filter.state) query = query.where('state', filter.state);
+    if (filter.sender_address) query = query.where('sender_address', filter.sender_address);
+    if (filter.contract_id) query = query.where('contract_id', filter.contract_id);
+
+    const [{ count }] = await query.clone().count('* as count');
+    const data = await query.orderBy('created_at', 'desc').limit(limit).offset(offset);
+
+    return { data: data as Escrow[], total: Number(count), page, limit };
+  }
+
+  // ─── Horizon event processor ──────────────────────────────────────────────
+
+  /**
+   * Process a raw contract event emitted by the Soroban escrow contract.
+   * Maps event_type strings to the appropriate service method.
+   */
+  async processContractEvent(event: {
+    contract_escrow_id: string;
+    contract_id: string;
+    event_type: string;
+    tx_hash: string;
+    ledger_sequence: number;
+    sender_address?: string;
+    farmer_address?: string;
+    vendor_id?: string;
+    amount?: number;
+    currency?: string;
+    crop_season?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<void> {
+    const stateMap: Record<string, EscrowState> = {
+      fund: EscrowState.Created,
+      approve_farmer: EscrowState.Funded,
+      mint_voucher: EscrowState.VoucherMinted,
+      redeem_voucher: EscrowState.Redeemed,
+      trigger_repay: EscrowState.Repaying,
+      repay: EscrowState.Repaid,
+      default: EscrowState.Defaulted,
+      cancel: EscrowState.Cancelled,
+    };
+
+    const newState = stateMap[event.event_type];
+    if (!newState) {
+      this.logger.warn('Unknown contract event type', { event_type: event.event_type });
+      return;
+    }
+
+    if (event.event_type === 'fund') {
+      await this.createEscrow({
+        contract_escrow_id: event.contract_escrow_id,
+        contract_id: event.contract_id,
+        state: EscrowState.Created,
+        sender_address: event.sender_address ?? '',
+        farmer_address: event.farmer_address,
+        vendor_id: event.vendor_id,
+        amount: event.amount ?? 0,
+        currency: event.currency ?? 'USDC',
+        crop_season: event.crop_season,
+        last_ledger_sequence: event.ledger_sequence,
+        last_tx_hash: event.tx_hash,
+      });
+    } else {
+      await this.applyStateTransition({
+        contract_escrow_id: event.contract_escrow_id,
+        new_state: newState,
+        tx_hash: event.tx_hash,
+        ledger_sequence: event.ledger_sequence,
+        event_type: event.event_type,
+        metadata: event.metadata,
+      });
+    }
+  }
+}

--- a/Backend/backend-api/src/utils/logger.ts
+++ b/Backend/backend-api/src/utils/logger.ts
@@ -1,13 +1,19 @@
 export class Logger {
-    info(message: string, meta?: unknown) {
-      console.log(`[INFO] ${message}`, meta ?? '');
-    }
-  
-    warn(message: string, meta?: unknown) {
-      console.warn(`[WARN] ${message}`, meta ?? '');
-    }
-  
-    error(message: string, meta?: unknown) {
-      console.error(`[ERROR] ${message}`, meta ?? '');
-    }
+  constructor(private readonly context?: string) {}
+
+  info(message: string, meta?: unknown) {
+    console.log(`[INFO]${this.context ? ` [${this.context}]` : ''} ${message}`, meta ?? '');
   }
+
+  warn(message: string, meta?: unknown) {
+    console.warn(`[WARN]${this.context ? ` [${this.context}]` : ''} ${message}`, meta ?? '');
+  }
+
+  error(message: string, meta?: unknown) {
+    console.error(`[ERROR]${this.context ? ` [${this.context}]` : ''} ${message}`, meta ?? '');
+  }
+}
+
+export function createLogger(context: string): Logger {
+  return new Logger(context);
+}


### PR DESCRIPTION
## Summary

Closes #13

Implements a complete escrow state synchronization system that mirrors on-chain Soroban escrow contract state into the backend database.

---

## Changes

### New files
| File | Purpose |
|---|---|
| `src/models/Escrow.ts` | TypeScript types, `EscrowState` enum, `VALID_TRANSITIONS` map, `isValidTransition` helper |
| `src/db/migrations/20260519_create_escrows.ts` | Knex migration — creates `escrows` and `escrow_history` tables |
| `src/db/index.ts` | Lazy Knex singleton (avoids `pg` import in unit tests) |
| `src/services/escrow.sync.service.ts` | Core sync service (see below) |
| `src/routes/escrows.routes.ts` | REST API routes |
| `src/__tests__/escrow.sync.test.ts` | 22 unit tests |

### Modified files
| File | Change |
|---|---|
| `src/utils/logger.ts` | Added `createLogger(context)` factory |
| `src/index.ts` | Wired `/api/escrows` routes |

---

## Architecture

### State machine
Mirrors the Soroban contract exactly:
```
Created → Funded → VoucherMinted → Redeemed → Repaying → Repaid
                                                        ↘ Defaulted
Created → Cancelled
Funded  → Cancelled
```

### Conflict resolution (in `applyStateTransition`)
Three guards prevent data corruption from out-of-order or replayed events:
1. **Duplicate guard** — same `tx_hash` + same `state` → silent skip
2. **Stale event guard** — incoming `ledger_sequence ≤` stored → skip with warning
3. **Invalid transition guard** — not in `VALID_TRANSITIONS[currentState]` → skip with warning

### History tracking
Every state change appends an immutable row to `escrow_history` with `from_state`, `to_state`, `tx_hash`, `ledger_sequence`, `event_type`, and optional `metadata`.

### Horizon event ingestion
`processContractEvent` maps Soroban event type strings (`fund`, `approve_farmer`, `mint_voucher`, `redeem_voucher`, `trigger_repay`, `repay`, `default`, `cancel`) to the appropriate service method.

---

## API

| Method | Path | Description |
|---|---|---|
| `GET` | `/api/escrows` | List escrows (filter: `state`, `sender_address`, `contract_id`, `page`, `limit`) |
| `GET` | `/api/escrows/:id` | Get escrow by internal UUID |
| `GET` | `/api/escrows/contract/:contractEscrowId` | Get escrow by on-chain ID |
| `GET` | `/api/escrows/:id/history` | Full state-transition audit log |
| `POST` | `/api/escrows/sync` | Ingest a contract event (Horizon indexer or manual) |

---

## Tests

22 unit tests — all passing, zero regressions on existing suite:

- **`isValidTransition`** — all valid forward paths + all invalid/terminal rejections
- **`createEscrow`** — happy path insert, idempotent duplicate skip
- **`applyStateTransition`** — valid transition, duplicate skip, stale skip, invalid transition rejection, not-found null return
- **`processContractEvent`** — `fund` routes to `createEscrow`, non-fund routes to `applyStateTransition`, unknown event types ignored
- **`getHistory`** — returns ordered history entries

```
Tests: 22 passed (escrow), 6 pre-existing failures unrelated to this PR
```

---

## DB migration

Run after merging:
```bash
knex migrate:latest
```

Tables created: `escrows`, `escrow_history`