### PR TITLE
gas-Profiler-enhancment

### DIFF
--- a/.github/workflows/contract-build.yml
+++ b/.github/workflows/contract-build.yml
@@ -1,0 +1,33 @@
+name: Contract Build
+
+on:
+  push:
+    paths:
+      - 'Contracts/**'
+  pull_request:
+    paths:
+      - 'Contracts/**'
+
+jobs:
+  cargo-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache Cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Build contract crate
+        working-directory: Contracts/escrow
+        run: cargo build --release

--- a/Contracts/escrow/src/gas_profiler.rs
+++ b/Contracts/escrow/src/gas_profiler.rs
@@ -5,22 +5,22 @@
 
 use soroban_sdk::Env;
 
-/// Gas cost constants (in stroops, 1 stroop = 0.00001 lumens)
+/// Gas cost constants (in stroops, 1 stroop = 0.0000001 XLM)
 /// These are empirically measured baseline costs on Soroban testnet
 pub mod gas_costs {
     /// Storage operations costs
     pub const STORAGE_READ_COST: u32 = 5_000;      // Read from persistent storage
     pub const STORAGE_WRITE_COST: u32 = 15_000;    // Write to persistent storage
     pub const STORAGE_DELETE_COST: u32 = 10_000;   // Delete from storage
-    
+
     /// Cryptographic operations
     pub const SHA256_COST: u32 = 3_000;            // SHA256 hash operation
     pub const VERIFY_SIG_COST: u32 = 25_000;       // Signature verification
-    
+
     /// Token operations
     pub const TOKEN_TRANSFER_COST: u32 = 45_000;   // Token transfer
     pub const TOKEN_BURN_COST: u32 = 35_000;       // Token burn/balance update
-    
+
     /// Escrow operations (aggregate estimates)
     pub const FUND_ESCROW_BASE: u32 = 60_000;      // Escrow fund operation
     pub const APPROVE_FARMER_BASE: u32 = 50_000;   // Farmer approval
@@ -31,40 +31,90 @@ pub mod gas_costs {
 }
 
 /// Profile metric for a contract operation
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct GasMetric {
     pub operation: &'static str,
     pub estimated_cost: u32,
     pub storage_reads: u32,
     pub storage_writes: u32,
+    pub storage_deletes: u32,
     pub transfers: u32,
+    pub hashes: u32,
+    pub sig_verifications: u32,
 }
 
 impl GasMetric {
     pub fn new(operation: &'static str) -> Self {
         GasMetric {
             operation,
-            estimated_cost: 0,
-            storage_reads: 0,
-            storage_writes: 0,
-            transfers: 0,
+            ..Default::default()
         }
     }
 
-    /// Calculate total estimated cost based on operations
+    /// Set storage read/write counts (builder-style)
+    pub fn with_storage(mut self, reads: u32, writes: u32) -> Self {
+        self.storage_reads = reads;
+        self.storage_writes = writes;
+        self
+    }
+
+    /// Set storage delete count (builder-style)
+    pub fn with_deletes(mut self, deletes: u32) -> Self {
+        self.storage_deletes = deletes;
+        self
+    }
+
+    /// Set token transfer count (builder-style)
+    pub fn with_transfers(mut self, transfers: u32) -> Self {
+        self.transfers = transfers;
+        self
+    }
+
+    /// Set cryptographic operation counts (builder-style)
+    pub fn with_crypto(mut self, hashes: u32, sig_verifications: u32) -> Self {
+        self.hashes = hashes;
+        self.sig_verifications = sig_verifications;
+        self
+    }
+
+    /// Calculate total estimated cost based on operations.
+    /// Uses saturating arithmetic to avoid overflow/panics on extreme inputs.
     pub fn calculate_cost(&mut self) {
-        self.estimated_cost = (self.storage_reads * gas_costs::STORAGE_READ_COST)
-            + (self.storage_writes * gas_costs::STORAGE_WRITE_COST)
-            + (self.transfers * gas_costs::TOKEN_TRANSFER_COST);
+        self.estimated_cost = self
+            .storage_reads
+            .saturating_mul(gas_costs::STORAGE_READ_COST)
+            .saturating_add(
+                self.storage_writes
+                    .saturating_mul(gas_costs::STORAGE_WRITE_COST),
+            )
+            .saturating_add(
+                self.storage_deletes
+                    .saturating_mul(gas_costs::STORAGE_DELETE_COST),
+            )
+            .saturating_add(
+                self.transfers
+                    .saturating_mul(gas_costs::TOKEN_TRANSFER_COST),
+            )
+            .saturating_add(self.hashes.saturating_mul(gas_costs::SHA256_COST))
+            .saturating_add(
+                self.sig_verifications
+                    .saturating_mul(gas_costs::VERIFY_SIG_COST),
+            );
+    }
+
+    /// Finalize the metric by computing its estimated cost (builder-style)
+    pub fn finalize(mut self) -> Self {
+        self.calculate_cost();
+        self
     }
 }
 
 /// Gas limit enforcement structure
 pub struct GasLimitConfig {
-    pub max_repayment_batch_size: usize,    // Max farmers in batch operation
-    pub max_history_retention: usize,       // Max repayment history entries stored
-    pub max_lazy_load_batch: usize,         // Max items to lazy load per call
-    pub enable_cost_check: bool,            // Enable on-chain cost verification
+    pub max_repayment_batch_size: usize, // Max farmers in batch operation
+    pub max_history_retention: usize,    // Max repayment history entries stored
+    pub max_lazy_load_batch: usize,      // Max items to lazy load per call
+    pub enable_cost_check: bool,         // Enable on-chain cost verification
 }
 
 impl Default for GasLimitConfig {
@@ -78,20 +128,63 @@ impl Default for GasLimitConfig {
     }
 }
 
-/// Publish gas metric event for off-chain analysis
-pub fn publish_gas_metric(_env: &Env, metric: &GasMetric) {
-    // In production, this would emit an event with the metric
-    // Events are lower-cost than storage and visible off-chain
-    // Example: env.events().publish((symbol_short!("gas"), metric.operation), metric.estimated_cost);
-    
-    // For now, this is a no-op to avoid adding cost during development
-    // Can be enabled with a feature flag for profiling
-    let _ = metric;
+impl GasLimitConfig {
+    /// Validate that a requested batch size is within configured limits.
+    pub fn validate_batch_size(&self, size: usize) -> Result<(), &'static str> {
+        if size == 0 {
+            return Err("batch size must be non-zero");
+        }
+        if size > self.max_repayment_batch_size {
+            return Err("batch size exceeds configured maximum");
+        }
+        Ok(())
+    }
+
+    /// Validate that a requested lazy-load batch size is within configured limits.
+    pub fn validate_lazy_load_batch(&self, size: usize) -> Result<(), &'static str> {
+        if size == 0 {
+            return Err("lazy load batch size must be non-zero");
+        }
+        if size > self.max_lazy_load_batch {
+            return Err("lazy load batch size exceeds configured maximum");
+        }
+        Ok(())
+    }
+
+    /// Validate that history retention count is within configured limits.
+    pub fn validate_history_retention(&self, count: usize) -> Result<(), &'static str> {
+        if count > self.max_history_retention {
+            return Err("history retention exceeds configured maximum");
+        }
+        Ok(())
+    }
+}
+
+/// Publish gas metric event for off-chain analysis.
+///
+/// When the `gas-profiling` feature is enabled, this emits an on-chain event
+/// containing the operation name and estimated cost. Events are lower-cost
+/// than storage writes and are visible to off-chain indexers.
+///
+/// When the feature is disabled (default), this is a zero-cost no-op so that
+/// production builds incur no overhead from profiling.
+#[cfg(feature = "gas-profiling")]
+pub fn publish_gas_metric(env: &Env, metric: &GasMetric) {
+    env.events().publish(
+        (soroban_sdk::symbol_short!("gas"), metric.operation),
+        metric.estimated_cost,
+    );
+}
+
+#[cfg(not(feature = "gas-profiling"))]
+pub fn publish_gas_metric(_env: &Env, _metric: &GasMetric) {
+    // No-op in production builds to avoid added cost.
 }
 
 /// Estimate gas cost for fund operation
 pub fn estimate_fund_cost(transfers: u32) -> u32 {
-    gas_costs::FUND_ESCROW_BASE + (transfers * gas_costs::TOKEN_TRANSFER_COST)
+    gas_costs::FUND_ESCROW_BASE
+        .saturating_add(transfers.saturating_mul(gas_costs::TOKEN_TRANSFER_COST))
 }
 
 /// Estimate gas cost for approve farmer operation
@@ -101,19 +194,30 @@ pub fn estimate_approve_cost() -> u32 {
 
 /// Estimate gas cost for redeem voucher operation
 pub fn estimate_redeem_cost(transfers: u32) -> u32 {
-    gas_costs::REDEEM_VOUCHER_BASE + (transfers * gas_costs::TOKEN_TRANSFER_COST)
+    gas_costs::REDEEM_VOUCHER_BASE
+        .saturating_add(transfers.saturating_mul(gas_costs::TOKEN_TRANSFER_COST))
 }
 
 /// Estimate gas cost for repay operation
 pub fn estimate_repay_cost(transfers: u32) -> u32 {
-    gas_costs::REPAY_BASE + (transfers * gas_costs::TOKEN_TRANSFER_COST)
+    gas_costs::REPAY_BASE
+        .saturating_add(transfers.saturating_mul(gas_costs::TOKEN_TRANSFER_COST))
 }
 
-/// Estimate gas cost for batch repay
+/// Estimate gas cost for batch repay.
+///
+/// Uses saturating arithmetic throughout since `batch_size` may be derived
+/// from external/user-controlled input and should not be able to panic or
+/// silently wrap on overflow.
 pub fn estimate_batch_repay_cost(batch_size: u32) -> u32 {
-    gas_costs::BATCH_REPAY_BASE 
-        + (batch_size * gas_costs::BATCH_REPAY_OVERHEAD_PER)
-        + (batch_size * gas_costs::TOKEN_TRANSFER_COST * 2) // transfers per item
+    let overhead = batch_size.saturating_mul(gas_costs::BATCH_REPAY_OVERHEAD_PER);
+    let transfer_cost = batch_size
+        .saturating_mul(gas_costs::TOKEN_TRANSFER_COST)
+        .saturating_mul(2); // transfers per item
+
+    gas_costs::BATCH_REPAY_BASE
+        .saturating_add(overhead)
+        .saturating_add(transfer_cost)
 }
 
 #[cfg(test)]
@@ -127,10 +231,36 @@ mod tests {
         metric.storage_writes = 1;
         metric.transfers = 1;
         metric.calculate_cost();
-        
+
         let expected = (2 * gas_costs::STORAGE_READ_COST)
             + (1 * gas_costs::STORAGE_WRITE_COST)
             + (1 * gas_costs::TOKEN_TRANSFER_COST);
+        assert_eq!(metric.estimated_cost, expected);
+    }
+
+    #[test]
+    fn test_gas_metric_builder_api() {
+        let metric = GasMetric::new("fund_escrow")
+            .with_storage(1, 2)
+            .with_transfers(1)
+            .with_crypto(1, 0)
+            .finalize();
+
+        let expected = (1 * gas_costs::STORAGE_READ_COST)
+            + (2 * gas_costs::STORAGE_WRITE_COST)
+            + (1 * gas_costs::TOKEN_TRANSFER_COST)
+            + (1 * gas_costs::SHA256_COST);
+        assert_eq!(metric.estimated_cost, expected);
+    }
+
+    #[test]
+    fn test_gas_metric_includes_deletes_and_sig_verification() {
+        let metric = GasMetric::new("redeem_voucher")
+            .with_deletes(1)
+            .with_crypto(0, 1)
+            .finalize();
+
+        let expected = gas_costs::STORAGE_DELETE_COST + gas_costs::VERIFY_SIG_COST;
         assert_eq!(metric.estimated_cost, expected);
     }
 
@@ -141,5 +271,36 @@ mod tests {
 
         let batch_cost = estimate_batch_repay_cost(10);
         assert!(batch_cost > gas_costs::BATCH_REPAY_BASE);
+    }
+
+    #[test]
+    fn test_batch_repay_overflow_safety() {
+        // Should saturate rather than panic or wrap on extreme input.
+        let cost = estimate_batch_repay_cost(u32::MAX);
+        assert_eq!(cost, u32::MAX);
+    }
+
+    #[test]
+    fn test_batch_size_validation() {
+        let cfg = GasLimitConfig::default();
+        assert!(cfg.validate_batch_size(1).is_ok());
+        assert!(cfg.validate_batch_size(50).is_ok());
+        assert!(cfg.validate_batch_size(51).is_err());
+        assert!(cfg.validate_batch_size(0).is_err());
+    }
+
+    #[test]
+    fn test_lazy_load_batch_validation() {
+        let cfg = GasLimitConfig::default();
+        assert!(cfg.validate_lazy_load_batch(100).is_ok());
+        assert!(cfg.validate_lazy_load_batch(101).is_err());
+        assert!(cfg.validate_lazy_load_batch(0).is_err());
+    }
+
+    #[test]
+    fn test_history_retention_validation() {
+        let cfg = GasLimitConfig::default();
+        assert!(cfg.validate_history_retention(500).is_ok());
+        assert!(cfg.validate_history_retention(501).is_err());
     }
 }


### PR DESCRIPTION
## PR: Enhance gas profiling module with validation, builder API, and overflow safety

### Summary
Extends the gas profiling/estimation module with stronger correctness guarantees, a more ergonomic API for building `GasMetric` instances, and enforceable limits via `GasLimitConfig`. No breaking changes to existing public function signatures (`estimate_*_cost` functions retain the same signatures and behavior for normal inputs).

### Changes

**1. `GasMetric` enhancements**
- Added `storage_deletes`, `hashes`, and `sig_verifications` fields so `calculate_cost` accounts for delete, SHA256, and signature-verification costs (previously defined as constants but unused in the cost calculation).
- Added a builder-style API: `with_storage`, `with_deletes`, `with_transfers`, `with_crypto`, and `finalize`, allowing concise construction like:
  ```rust
  GasMetric::new("fund_escrow")
      .with_storage(1, 2)
      .with_transfers(1)
      .finalize();
  ```
- `calculate_cost` now uses saturating arithmetic instead of plain multiplication/addition.

**2. `GasLimitConfig` validation methods**
- Added `validate_batch_size`, `validate_lazy_load_batch`, and `validate_history_retention`, which return `Result<(), &'static str>` and enforce the existing config thresholds (`max_repayment_batch_size`, `max_lazy_load_batch`, `max_history_retention`). Previously these fields were defined but never enforced anywhere.

**3. Overflow-safe cost estimation**
- All `estimate_*_cost` functions (`estimate_fund_cost`, `estimate_redeem_cost`, `estimate_repay_cost`, `estimate_batch_repay_cost`) now use `saturating_mul`/`saturating_add` instead of raw arithmetic, since `batch_size`/`transfers` may be influenced by external input and should not panic or silently wrap on overflow.

**4. `publish_gas_metric` behind a feature flag**
- Replaced the dead `let _ = metric;` no-op with two implementations gated on a new `gas-profiling` feature:
  - With the feature enabled: emits a real on-chain event via `env.events().publish(...)`.
  - Without it (default): remains a zero-cost no-op, preserving current production behavior.
- **Requires** adding a `gas-profiling` feature to `Cargo.toml`:
  ```toml
  [features]
  gas-profiling = []
  ```

**5. Doc fix**
- Corrected the stroop/XLM conversion comment (`1 stroop = 0.0000001 XLM`, was previously stated as `0.00001`).

**6. Tests**
- Added tests for the builder API, delete/signature-verification cost inclusion, batch-size/lazy-load/history-retention validation, and overflow saturation at `u32::MAX`.

### Risk / Compatibility
- `GasMetric` gained new fields; since the struct now derives `Default` and `GasMetric::new` initializes via `..Default::default()`, existing construction patterns (`GasMetric::new("op")` + field mutation) continue to work unchanged.
- `publish_gas_metric` behavior is unchanged by default (no-op) unless the new `gas-profiling` feature is explicitly enabled — requires a `Cargo.toml` update to take effect.
- All estimator function signatures and normal-range outputs are unchanged; only extreme/overflow inputs now saturate instead of wrapping.

### Follow-ups (not included in this PR)
- Wire `GasLimitConfig::validate_*` calls into the actual contract entry points (e.g., batch repay handler) to enforce limits at call time.
- Consider feature-flagging this crate's `gas-profiling` feature from the top-level workspace `Cargo.toml` if profiling needs to be toggled across multiple modules.